### PR TITLE
Add uid of the reported user to the log message content

### DIFF
--- a/src/commands/context/dont-ask-to-ask.ts
+++ b/src/commands/context/dont-ask-to-ask.ts
@@ -5,6 +5,6 @@ export const command = createReplyableMessageCommand({
   reply: {
     title: "Don't ask to ask, just ask!",
     content:
-      "Please ask your question directly. If someone knows the answer, they will reply. If you don't get an answer, you can try again later.\n\nAlso see: <https://dontasktoask.com/>",
+      'Please just ask your question directly: <https://dontasktoask.com/>',
   },
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,6 +27,7 @@ export const logAndDelete = async (
   ) as TextChannel;
 
   await modLogChannel.send({
+    content: message.author.id,
     embeds: [
       {
         title: 'Message deleted',


### PR DESCRIPTION
Make it easier to copy the uid on mobile to search for other messages and logs relevant to that user.