### PR TITLE
improve "like this" for "use code blocks commands" 

### DIFF
--- a/src/commands/context/reply-with-issue.ts
+++ b/src/commands/context/reply-with-issue.ts
@@ -79,7 +79,7 @@ export const responses: Option[] = [
       title: 'Please use code blocks',
       description: [
         'When sharing code or error messages, please use code blocks.',
-        'You can create a code block by wrapping your code in three backticks (`), like this: ```\ncode here\n```',
+        'You can create a code block by wrapping your code in three backticks (\\`), like this: \n> \\`\\`\\`ts \n> code here\n> \\`\\`\\`',
         'You can also specify the language in the code block (e.g. ts, js) to enable syntax highlighting:  ```ts\nexport default function Page(){}\n```',
         'Link a Gist to upload entire files: https://gist.github.com/',
         'Link a Code Sandbox to share runnable examples: https://codesandbox.io/s',


### PR DESCRIPTION
so that the code block is easily copy-pasteble

![image](https://github.com/user-attachments/assets/83b204a9-9e55-416b-bca0-5880e2156197)
